### PR TITLE
FIx when processing binary_compressed format point cloud

### DIFF
--- a/pypcd/pypcd.py
+++ b/pypcd/pypcd.py
@@ -77,8 +77,8 @@ def parse_header(lines):
     for ln in lines:
         if ln.startswith('#') or len(ln) < 2:
             continue
-        ln = ln.replace('_','s',1)
-        ln = ln.replace('_','m',1)
+        ln = ln.replace(' _ ',' s ',1)
+        ln = ln.replace(' _ ',' m ',1)
         match = re.match('(\w+)\s+([\w\s\.]+)', ln)
         if not match:
             warnings.warn("warning: can't understand line: %s" % ln)


### PR DESCRIPTION
When dealing with binary_compressed point cloud, the original code will replace the "_" as well, which will cause an error. Now the problem is fixed.