### PR TITLE
Fix fromstring

### DIFF
--- a/pypcd/__init__.py
+++ b/pypcd/__init__.py
@@ -1,2 +1,1 @@
-
 from pypcd import *

--- a/pypcd/nea_pc_format.py
+++ b/pypcd/nea_pc_format.py
@@ -1,198 +1,113 @@
-
 import copy
 import numpy as np
 from sensor_msgs.msg import PointField
 
 # these are from numpy_pc2
-_pftype_to_nptype = dict([(PointField.INT8, np.dtype('int8')),
-                          (PointField.UINT8, np.dtype('uint8')),
-                          (PointField.INT16, np.dtype('int16')),
-                          (PointField.UINT16, np.dtype('uint16')),
-                          (PointField.INT32, np.dtype('int32')),
-                          (PointField.UINT32, np.dtype('uint32')),
-                          (PointField.FLOAT32, np.dtype('float32')),
-                          (PointField.FLOAT64, np.dtype('float64'))])
+_pftype_to_nptype = dict(
+    [
+        (PointField.INT8, np.dtype("int8")),
+        (PointField.UINT8, np.dtype("uint8")),
+        (PointField.INT16, np.dtype("int16")),
+        (PointField.UINT16, np.dtype("uint16")),
+        (PointField.INT32, np.dtype("int32")),
+        (PointField.UINT32, np.dtype("uint32")),
+        (PointField.FLOAT32, np.dtype("float32")),
+        (PointField.FLOAT64, np.dtype("float64")),
+    ]
+)
 
-_pftype_to_pcd_letter = dict([(PointField.INT8, 'I'),
-                              (PointField.UINT8, 'U'),
-                              (PointField.INT16, 'I'),
-                              (PointField.UINT16, 'U'),
-                              (PointField.INT32, 'I'),
-                              (PointField.UINT32, 'U'),
-                              (PointField.FLOAT32, 'F'),
-                              (PointField.FLOAT64, 'F')])
+_pftype_to_pcd_letter = dict(
+    [
+        (PointField.INT8, "I"),
+        (PointField.UINT8, "U"),
+        (PointField.INT16, "I"),
+        (PointField.UINT16, "U"),
+        (PointField.INT32, "I"),
+        (PointField.UINT32, "U"),
+        (PointField.FLOAT32, "F"),
+        (PointField.FLOAT64, "F"),
+    ]
+)
 
-_pftype_to_size = dict([(PointField.INT8, 1),
-                        (PointField.UINT8, 1),
-                        (PointField.INT16, 2),
-                        (PointField.UINT16, 2),
-                        (PointField.INT32, 4),
-                        (PointField.UINT32, 4),
-                        (PointField.FLOAT32, 4),
-                        (PointField.FLOAT64, 8)])
-
-
-_nea_field_dicts =[\
-{'name':'x',
- 'offset': 0,
- 'datatype': PointField.FLOAT64,
- 'count': 1
-},
-{'name':'y',
- 'offset': 8,
- 'datatype': PointField.FLOAT64,
- 'count': 1
-},
-{'name':'z',
- 'offset': 16,
- 'datatype': PointField.FLOAT64,
- 'count': 1
-},
-{'name':'x_origin',
- 'offset': 24,
- 'datatype': PointField.FLOAT64,
- 'count': 1
-},
-{'name':'y_origin',
- 'offset': 32,
- 'datatype': PointField.FLOAT64,
- 'count': 1
-},
-{'name':'z_origin',
- 'offset': 40,
- 'datatype': PointField.FLOAT64,
- 'count': 1
-},
-{'name':'range_variance',
- 'offset': 48,
- 'datatype': PointField.FLOAT32,
- 'count': 1
-},
-{'name':'x_variance',
- 'offset': 52,
- 'datatype': PointField.FLOAT32,
- 'count': 1
-},
-{'name':'y_variance',
- 'offset': 56,
- 'datatype': PointField.FLOAT32,
- 'count': 1
-},
-{'name':'z_variance',
- 'offset': 60,
- 'datatype': PointField.FLOAT32,
- 'count': 1
-},
-{'name':'reflectance',
- 'offset': 64,
- 'datatype': PointField.FLOAT32,
- 'count': 1
-},
-{'name':'time_sec',
- 'offset': 68,
- 'datatype': PointField.UINT32,
- 'count': 1
-},
-{'name':'time_nsec',
- 'offset': 72,
- 'datatype': PointField.UINT32,
- 'count': 1
-},
-{'name':'return_type',
- 'offset': 76,
- 'datatype': PointField.UINT8,
- 'count': 1
-}]
-
-_nea_float_fields_dicts =[\
-{'name':'x',
- 'offset': 0,
- 'datatype': PointField.FLOAT32,
- 'count': 1
-},
-{'name':'y',
- 'offset': 4,
- 'datatype': PointField.FLOAT32,
- 'count': 1
-},
-{'name':'z',
- 'offset': 8,
- 'datatype': PointField.FLOAT32,
- 'count': 1
-},
-{'name':'x_origin',
- 'offset': 12,
- 'datatype': PointField.FLOAT32,
- 'count': 1
-},
-{'name':'y_origin',
- 'offset': 16,
- 'datatype': PointField.FLOAT32,
- 'count': 1
-},
-{'name':'z_origin',
- 'offset': 20,
- 'datatype': PointField.FLOAT32,
- 'count': 1
-},
-{'name':'range_variance',
- 'offset': 24,
- 'datatype': PointField.FLOAT32,
- 'count': 1
-},
-{'name':'x_variance',
- 'offset': 28,
- 'datatype': PointField.FLOAT32,
- 'count': 1
-},
-{'name':'y_variance',
- 'offset': 32,
- 'datatype': PointField.FLOAT32,
- 'count': 1
-},
-{'name':'z_variance',
- 'offset': 36,
- 'datatype': PointField.FLOAT32,
- 'count': 1
-},
-{'name':'reflectance',
- 'offset': 40,
- 'datatype': PointField.FLOAT32,
- 'count': 1
-},
-{'name':'time_sec',
- 'offset': 44,
- 'datatype': PointField.UINT32,
- 'count': 1
-},
-{'name':'time_nsec',
- 'offset': 48,
- 'datatype': PointField.UINT32,
- 'count': 1
-},
-{'name':'return_type',
- 'offset': 52,
- 'datatype': PointField.UINT8,
- 'count': 1
-}]
+_pftype_to_size = dict(
+    [
+        (PointField.INT8, 1),
+        (PointField.UINT8, 1),
+        (PointField.INT16, 2),
+        (PointField.UINT16, 2),
+        (PointField.INT32, 4),
+        (PointField.UINT32, 4),
+        (PointField.FLOAT32, 4),
+        (PointField.FLOAT64, 8),
+    ]
+)
 
 
-_label_field_dict = {'name':'label',
-                    'offset':0,
-                    'datatype': PointField.UINT8,
-                    'count':1}
+_nea_field_dicts = [
+    {"name": "x", "offset": 0, "datatype": PointField.FLOAT64, "count": 1},
+    {"name": "y", "offset": 8, "datatype": PointField.FLOAT64, "count": 1},
+    {"name": "z", "offset": 16, "datatype": PointField.FLOAT64, "count": 1},
+    {"name": "x_origin", "offset": 24, "datatype": PointField.FLOAT64, "count": 1},
+    {"name": "y_origin", "offset": 32, "datatype": PointField.FLOAT64, "count": 1},
+    {"name": "z_origin", "offset": 40, "datatype": PointField.FLOAT64, "count": 1},
+    {
+        "name": "range_variance",
+        "offset": 48,
+        "datatype": PointField.FLOAT32,
+        "count": 1,
+    },
+    {"name": "x_variance", "offset": 52, "datatype": PointField.FLOAT32, "count": 1},
+    {"name": "y_variance", "offset": 56, "datatype": PointField.FLOAT32, "count": 1},
+    {"name": "z_variance", "offset": 60, "datatype": PointField.FLOAT32, "count": 1},
+    {"name": "reflectance", "offset": 64, "datatype": PointField.FLOAT32, "count": 1},
+    {"name": "time_sec", "offset": 68, "datatype": PointField.UINT32, "count": 1},
+    {"name": "time_nsec", "offset": 72, "datatype": PointField.UINT32, "count": 1},
+    {"name": "return_type", "offset": 76, "datatype": PointField.UINT8, "count": 1},
+]
+
+_nea_float_fields_dicts = [
+    {"name": "x", "offset": 0, "datatype": PointField.FLOAT32, "count": 1},
+    {"name": "y", "offset": 4, "datatype": PointField.FLOAT32, "count": 1},
+    {"name": "z", "offset": 8, "datatype": PointField.FLOAT32, "count": 1},
+    {"name": "x_origin", "offset": 12, "datatype": PointField.FLOAT32, "count": 1},
+    {"name": "y_origin", "offset": 16, "datatype": PointField.FLOAT32, "count": 1},
+    {"name": "z_origin", "offset": 20, "datatype": PointField.FLOAT32, "count": 1},
+    {
+        "name": "range_variance",
+        "offset": 24,
+        "datatype": PointField.FLOAT32,
+        "count": 1,
+    },
+    {"name": "x_variance", "offset": 28, "datatype": PointField.FLOAT32, "count": 1},
+    {"name": "y_variance", "offset": 32, "datatype": PointField.FLOAT32, "count": 1},
+    {"name": "z_variance", "offset": 36, "datatype": PointField.FLOAT32, "count": 1},
+    {"name": "reflectance", "offset": 40, "datatype": PointField.FLOAT32, "count": 1},
+    {"name": "time_sec", "offset": 44, "datatype": PointField.UINT32, "count": 1},
+    {"name": "time_nsec", "offset": 48, "datatype": PointField.UINT32, "count": 1},
+    {"name": "return_type", "offset": 52, "datatype": PointField.UINT8, "count": 1},
+]
+
+
+_label_field_dict = {
+    "name": "label",
+    "offset": 0,
+    "datatype": PointField.UINT8,
+    "count": 1,
+}
 
 # TODO if I use '_' for padding, like pcl, there are weird
 # interactions when using binary_compressed. PCL assumes
 # padding is not included in compressed files (which makes sense).
-_padding_field_dict = {'name': '_PAD',
-                      'offset':0,
-                      'datatype': PointField.UINT8,
-                      'count': 0}
+_padding_field_dict = {
+    "name": "_PAD",
+    "offset": 0,
+    "datatype": PointField.UINT8,
+    "count": 0,
+}
+
 
 def datatype_to_size(datatype):
-    """ ROS pointfield datatype to size in bytes
-    """
+    """ROS pointfield datatype to size in bytes"""
     if datatype in (PointField.INT8, PointField.UINT8):
         return 1
     elif datatype in (PointField.INT16, PointField.UINT16):
@@ -202,77 +117,85 @@ def datatype_to_size(datatype):
     elif datatype in (PointField.FLOAT64,):
         return 8
 
+
 def make_nea_fields_dicts(with_label=True, with_padding=True):
     field_dicts = copy.deepcopy(_nea_field_dicts)
     if with_label:
         label_field_dict_copy = copy.deepcopy(_label_field_dict)
         # TODO this assumes last field is return_type
-        label_field_dict_copy['offset'] = field_dicts[-1]['offset']+1
+        label_field_dict_copy["offset"] = field_dicts[-1]["offset"] + 1
         field_dicts.append(label_field_dict_copy)
     if with_padding:
         padding_field_dict_copy = copy.deepcopy(_padding_field_dict)
         # TODO this assumes last field is return_type or label
-        padding_field_dict_copy['offset'] = field_dicts[-1]['offset']+1
+        padding_field_dict_copy["offset"] = field_dicts[-1]["offset"] + 1
         if with_label:
-            padding_field_dict_copy['count'] = 2
+            padding_field_dict_copy["count"] = 2
         else:
-            padding_field_dict_copy['count'] = 3
+            padding_field_dict_copy["count"] = 3
         field_dicts.append(padding_field_dict_copy)
     return field_dicts
+
 
 def make_nea_float_fields_dicts(with_label=True, with_padding=True):
     field_dicts = copy.deepcopy(_nea_float_fields_dicts)
     if with_label:
         label_field_dict_copy = copy.deepcopy(_label_field_dict)
         # TODO this assumes last field is return_type
-        label_field_dict_copy['offset'] = field_dicts[-1]['offset']+1
+        label_field_dict_copy["offset"] = field_dicts[-1]["offset"] + 1
         field_dicts.append(label_field_dict_copy)
     if with_padding:
         padding_field_dict_copy = copy.deepcopy(_padding_field_dict)
         # TODO this assumes last field is return_type or label
-        padding_field_dict_copy['offset'] = field_dicts[-1]['offset']+1
+        padding_field_dict_copy["offset"] = field_dicts[-1]["offset"] + 1
         if with_label:
-            padding_field_dict_copy['count'] = 9
+            padding_field_dict_copy["count"] = 9
         else:
-            padding_field_dict_copy['count'] = 10
+            padding_field_dict_copy["count"] = 10
         field_dicts.append(padding_field_dict_copy)
     return field_dicts
+
 
 def field_dict_list_to_dtypes(field_dicts):
     dtypes = []
     for f in field_dicts:
-        count = f['count']
+        count = f["count"]
         if count > 1:
             for c in xrange(count):
-                name = '%s_%04d'%(f['name'], c)
-                nptype = _pftype_to_nptype[f['datatype']]
-                dtypes.append( (name, nptype) )
+                name = "%s_%04d" % (f["name"], c)
+                nptype = _pftype_to_nptype[f["datatype"]]
+                dtypes.append((name, nptype))
         else:
-            name = f['name']
-            nptype = _pftype_to_nptype[f['datatype']]
-            dtypes.append( (name, nptype) )
+            name = f["name"]
+            nptype = _pftype_to_nptype[f["datatype"]]
+            dtypes.append((name, nptype))
     return dtypes
+
 
 def make_nea_dtypes(with_label=True, with_padding=True):
     fl = make_nea_fields_dicts(with_label=with_label, with_padding=with_padding)
     return field_dict_list_to_dtypes(fl)
 
+
 def make_nea_float_dtypes(with_label=True, with_padding=True):
     fl = make_nea_float_fields_dicts(with_label=with_label, with_padding=with_padding)
     return field_dict_list_to_dtypes(fl)
 
+
 def field_dict_list_to_pcd_metadata(field_dict_list):
-    pcd_md = {'version':.7,
-              'fields':[f['name'] for f in field_dict_list],
-              'size':[ _pftype_to_size[f['datatype']] for f in field_dict_list],
-              'type':[ _pftype_to_pcd_letter[f['datatype']] for f in field_dict_list],
-              'count':[ f['count'] for f in field_dict_list ],
-              'width':0,
-              'height':1,
-              'viewpoint':[0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0],
-              'points':0,
-              'data':'ASCII'}
+    pcd_md = {
+        "version": 0.7,
+        "fields": [f["name"] for f in field_dict_list],
+        "size": [_pftype_to_size[f["datatype"]] for f in field_dict_list],
+        "type": [_pftype_to_pcd_letter[f["datatype"]] for f in field_dict_list],
+        "count": [f["count"] for f in field_dict_list],
+        "width": 0,
+        "height": 1,
+        "viewpoint": [0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0],
+        "points": 0,
+        "data": "ASCII",
+    }
     return pcd_md
 
-#nea_fields = [ PointField(**d) for d in nea_fields_dicts]
 
+# nea_fields = [ PointField(**d) for d in nea_fields_dicts]

--- a/pypcd/numpy_pc2.py
+++ b/pypcd/numpy_pc2.py
@@ -134,14 +134,14 @@ def pointcloud2_to_array(cloud_msg, split_rgb=False, remove_padding=True):
 
     Reshapes the returned array to have shape (height, width), even if the height is 1.
 
-    The reason for using np.fromstring rather than struct.unpack is speed... especially
+    The reason for using np.frombuffer rather than struct.unpack is speed... especially
     for large point clouds, this will be <much> faster.
     """
     # construct a numpy record type equivalent to the point type of this cloud
     dtype_list = pointcloud2_to_dtype(cloud_msg)
 
     # parse the cloud into an array
-    cloud_arr = np.fromstring(cloud_msg.data, dtype_list)
+    cloud_arr = np.frombuffer(cloud_msg.data, dtype_list)
 
     # remove the dummy fields that were added
     if remove_padding:

--- a/pypcd/numpy_pc2.py
+++ b/pypcd/numpy_pc2.py
@@ -33,9 +33,9 @@
 # Author: Jon Binney
 # Updates: Daniel Maturana
 
-'''
+"""
 Functions for working with PointCloud2.
-'''
+"""
 __docformat__ = "restructuredtext en"
 
 import numpy as np
@@ -45,68 +45,78 @@ from sensor_msgs.msg import PointCloud2
 
 # prefix to the names of dummy fields we add to get byte alignment correct. this needs to not
 # clash with any actual field names
-DUMMY_FIELD_PREFIX = '__'
+DUMMY_FIELD_PREFIX = "__"
 
 # mappings between PointField types and numpy types
-type_mappings = [(PointField.INT8, np.dtype('int8')),
-                 (PointField.UINT8, np.dtype('uint8')),
-                 (PointField.INT16, np.dtype('int16')),
-                 (PointField.UINT16, np.dtype('uint16')),
-                 (PointField.INT32, np.dtype('int32')),
-                 (PointField.UINT32, np.dtype('uint32')),
-                 (PointField.FLOAT32, np.dtype('float32')),
-                 (PointField.FLOAT64, np.dtype('float64'))]
+type_mappings = [
+    (PointField.INT8, np.dtype("int8")),
+    (PointField.UINT8, np.dtype("uint8")),
+    (PointField.INT16, np.dtype("int16")),
+    (PointField.UINT16, np.dtype("uint16")),
+    (PointField.INT32, np.dtype("int32")),
+    (PointField.UINT32, np.dtype("uint32")),
+    (PointField.FLOAT32, np.dtype("float32")),
+    (PointField.FLOAT64, np.dtype("float64")),
+]
 
 pftype_to_nptype = dict(type_mappings)
 nptype_to_pftype = dict((nptype, pftype) for pftype, nptype in type_mappings)
 
 # sizes (in bytes) of PointField types
-pftype_sizes = {PointField.INT8: 1, PointField.UINT8: 1, PointField.INT16: 2, PointField.UINT16: 2,
-                PointField.INT32: 4, PointField.UINT32: 4, PointField.FLOAT32: 4, PointField.FLOAT64: 8}
+pftype_sizes = {
+    PointField.INT8: 1,
+    PointField.UINT8: 1,
+    PointField.INT16: 2,
+    PointField.UINT16: 2,
+    PointField.INT32: 4,
+    PointField.UINT32: 4,
+    PointField.FLOAT32: 4,
+    PointField.FLOAT64: 8,
+}
+
 
 def pointfields_to_dtype(point_fields):
-    '''Convert a list of PointFields to a numpy record datatype.
-    '''
+    """Convert a list of PointFields to a numpy record datatype."""
     offset = 0
     np_dtype_list = []
     for f in point_fields:
         while offset < f.offset:
             # might be extra padding between fields
-            np_dtype_list.append(('%s%d' % (DUMMY_FIELD_PREFIX, offset), np.uint8))
+            np_dtype_list.append(("%s%d" % (DUMMY_FIELD_PREFIX, offset), np.uint8))
             offset += 1
         np_dtype_list.append((f.name, pftype_to_nptype[f.datatype]))
         offset += pftype_sizes[f.datatype]
 
     # might be extra padding between points
-    #while offset < cloud_msg.point_step:
-        #np_dtype_list.append(('%s%d' % (DUMMY_FIELD_PREFIX, offset), np.uint8))
-        #offset += 1
+    # while offset < cloud_msg.point_step:
+    # np_dtype_list.append(('%s%d' % (DUMMY_FIELD_PREFIX, offset), np.uint8))
+    # offset += 1
 
     return np_dtype_list
 
+
 def pointcloud2_to_dtype(cloud_msg):
-    '''Convert a list of PointFields to a numpy record datatype.
-    '''
+    """Convert a list of PointFields to a numpy record datatype."""
     offset = 0
     np_dtype_list = []
     for f in cloud_msg.fields:
         while offset < f.offset:
             # might be extra padding between fields
-            np_dtype_list.append(('%s%d' % (DUMMY_FIELD_PREFIX, offset), np.uint8))
+            np_dtype_list.append(("%s%d" % (DUMMY_FIELD_PREFIX, offset), np.uint8))
             offset += 1
         np_dtype_list.append((f.name, pftype_to_nptype[f.datatype]))
         offset += pftype_sizes[f.datatype]
 
     # might be extra padding between points
     while offset < cloud_msg.point_step:
-        np_dtype_list.append(('%s%d' % (DUMMY_FIELD_PREFIX, offset), np.uint8))
+        np_dtype_list.append(("%s%d" % (DUMMY_FIELD_PREFIX, offset), np.uint8))
         offset += 1
 
     return np_dtype_list
 
+
 def arr_to_fields(cloud_arr):
-    '''Convert a numpy record datatype into a list of PointFields.
-    '''
+    """Convert a numpy record datatype into a list of PointFields."""
     fields = []
     for field_name in cloud_arr.dtype.names:
         np_field_type, field_offset = cloud_arr.dtype.fields[field_name]
@@ -114,18 +124,19 @@ def arr_to_fields(cloud_arr):
         pf.name = field_name
         pf.datatype = nptype_to_pftype[np_field_type]
         pf.offset = field_offset
-        pf.count = 1 # is this ever more than one?
+        pf.count = 1  # is this ever more than one?
         fields.append(pf)
     return fields
 
+
 def pointcloud2_to_array(cloud_msg, split_rgb=False, remove_padding=True):
-    ''' Converts a rospy PointCloud2 message to a numpy recordarray
+    """Converts a rospy PointCloud2 message to a numpy recordarray
 
     Reshapes the returned array to have shape (height, width), even if the height is 1.
 
     The reason for using np.fromstring rather than struct.unpack is speed... especially
     for large point clouds, this will be <much> faster.
-    '''
+    """
     # construct a numpy record type equivalent to the point type of this cloud
     dtype_list = pointcloud2_to_dtype(cloud_msg)
 
@@ -135,78 +146,137 @@ def pointcloud2_to_array(cloud_msg, split_rgb=False, remove_padding=True):
     # remove the dummy fields that were added
     if remove_padding:
         cloud_arr = cloud_arr[
-            [fname for fname, _type in dtype_list if not (fname[:len(DUMMY_FIELD_PREFIX)] == DUMMY_FIELD_PREFIX)]]
+            [
+                fname
+                for fname, _type in dtype_list
+                if not (fname[: len(DUMMY_FIELD_PREFIX)] == DUMMY_FIELD_PREFIX)
+            ]
+        ]
 
     if split_rgb:
         cloud_arr = split_rgb_field(cloud_arr)
 
     return np.reshape(cloud_arr, (cloud_msg.height, cloud_msg.width))
 
+
 def array_to_xyz_pointcloud2f(cloud_arr, stamp=None, frame_id=None, merge_rgb=False):
-    """ convert an Nx3 float array to an xyz point cloud.
+    """convert an Nx3 float array to an xyz point cloud.
     beware of numerical issues when casting from other types to float32.
     """
     cloud_arr = np.asarray(cloud_arr, dtype=np.float32)
-    if not cloud_arr.ndim==2: raise ValueError('cloud_arr must be 2D array')
-    if not cloud_arr.shape[1]==3: raise ValueError('cloud_arr shape must be Nx3')
-    xyz = cloud_arr.view(np.dtype([('x', np.float32), ('y', np.float32), ('z', np.float32)])).squeeze()
-    return array_to_pointcloud2(xyz, stamp=stamp, frame_id=frame_id, merge_rgb=merge_rgb)
+    if not cloud_arr.ndim == 2:
+        raise ValueError("cloud_arr must be 2D array")
+    if not cloud_arr.shape[1] == 3:
+        raise ValueError("cloud_arr shape must be Nx3")
+    xyz = cloud_arr.view(
+        np.dtype([("x", np.float32), ("y", np.float32), ("z", np.float32)])
+    ).squeeze()
+    return array_to_pointcloud2(
+        xyz, stamp=stamp, frame_id=frame_id, merge_rgb=merge_rgb
+    )
+
 
 def array_to_xyzi_pointcloud2f(cloud_arr, stamp=None, frame_id=None, merge_rgb=False):
-    """ convert an Nx4 float array to an xyzi point cloud.
+    """convert an Nx4 float array to an xyzi point cloud.
     beware of numerical issues when casting from other types to float32.
     """
     cloud_arr = np.asarray(cloud_arr, dtype=np.float32)
-    if not cloud_arr.ndim==2: raise ValueError('cloud_arr must be 2D array')
-    if not cloud_arr.shape[1]==4: raise ValueError('cloud_arr shape must be Nx4')
-    xyzi = cloud_arr.view(np.dtype([
-        ('x', np.float32), ('y', np.float32), ('z', np.float32), ('intensity', np.float32)
-        ])).squeeze()
-    return array_to_pointcloud2(xyzi, stamp=stamp, frame_id=frame_id, merge_rgb=merge_rgb)
+    if not cloud_arr.ndim == 2:
+        raise ValueError("cloud_arr must be 2D array")
+    if not cloud_arr.shape[1] == 4:
+        raise ValueError("cloud_arr shape must be Nx4")
+    xyzi = cloud_arr.view(
+        np.dtype(
+            [
+                ("x", np.float32),
+                ("y", np.float32),
+                ("z", np.float32),
+                ("intensity", np.float32),
+            ]
+        )
+    ).squeeze()
+    return array_to_pointcloud2(
+        xyzi, stamp=stamp, frame_id=frame_id, merge_rgb=merge_rgb
+    )
 
-def arrays_to_xyzi_pointcloud2f(cloud_arr, intensity_array, stamp=None, frame_id=None, merge_rgb=False):
-    """ convert an Nx3 float array and N array to an xyzi point cloud.
+
+def arrays_to_xyzi_pointcloud2f(
+    cloud_arr, intensity_array, stamp=None, frame_id=None, merge_rgb=False
+):
+    """convert an Nx3 float array and N array to an xyzi point cloud.
     beware of numerical issues when casting from other types to float32.
     """
     cloud_arr = np.asarray(cloud_arr, dtype=np.float32)
-    if not cloud_arr.ndim==2: raise ValueError('cloud_arr must be 2D array')
-    if not cloud_arr.shape[1]==3: raise ValueError('cloud_arr shape must be Nx3')
-    if not intensity_array.size == cloud_arr.shape[0]: raise ValueError('wrong intensity shape')
-    xyzi = np.zeros( (len(cloud_arr), 4) , dtype=np.float32 )
-    xyzi[:,0:3] = cloud_arr
-    xyzi[:,3] = intensity_array
-    xyzi = xyzi.view(np.dtype([
-        ('x', np.float32), ('y', np.float32), ('z', np.float32), ('intensity', np.float32)
-        ])).squeeze()
-    return array_to_pointcloud2(xyzi, stamp=stamp, frame_id=frame_id, merge_rgb=merge_rgb)
+    if not cloud_arr.ndim == 2:
+        raise ValueError("cloud_arr must be 2D array")
+    if not cloud_arr.shape[1] == 3:
+        raise ValueError("cloud_arr shape must be Nx3")
+    if not intensity_array.size == cloud_arr.shape[0]:
+        raise ValueError("wrong intensity shape")
+    xyzi = np.zeros((len(cloud_arr), 4), dtype=np.float32)
+    xyzi[:, 0:3] = cloud_arr
+    xyzi[:, 3] = intensity_array
+    xyzi = xyzi.view(
+        np.dtype(
+            [
+                ("x", np.float32),
+                ("y", np.float32),
+                ("z", np.float32),
+                ("intensity", np.float32),
+            ]
+        )
+    ).squeeze()
+    return array_to_pointcloud2(
+        xyzi, stamp=stamp, frame_id=frame_id, merge_rgb=merge_rgb
+    )
+
 
 def array_to_xyzl_pointcloud2f(cloud_arr, stamp=None, frame_id=None, merge_rgb=False):
-    """ convert an Nx4 float array to an xyzi point cloud.
+    """convert an Nx4 float array to an xyzi point cloud.
     beware of numerical issues when casting from other types to float32.
     """
     cloud_arr = np.asarray(cloud_arr, dtype=np.float32)
-    if not cloud_arr.ndim==2: raise ValueError('cloud_arr must be 2D array')
-    if not cloud_arr.shape[1]==4: raise ValueError('cloud_arr shape must be Nx3')
-    xyzi = cloud_arr.view(np.dtype([
-        ('x', np.float32), ('y', np.float32), ('z', np.float32), ('intensity', np.float32)
-        ])).squeeze()
-    return array_to_pointcloud2(xyzi, stamp=stamp, frame_id=frame_id, merge_rgb=merge_rgb)
+    if not cloud_arr.ndim == 2:
+        raise ValueError("cloud_arr must be 2D array")
+    if not cloud_arr.shape[1] == 4:
+        raise ValueError("cloud_arr shape must be Nx3")
+    xyzi = cloud_arr.view(
+        np.dtype(
+            [
+                ("x", np.float32),
+                ("y", np.float32),
+                ("z", np.float32),
+                ("intensity", np.float32),
+            ]
+        )
+    ).squeeze()
+    return array_to_pointcloud2(
+        xyzi, stamp=stamp, frame_id=frame_id, merge_rgb=merge_rgb
+    )
 
 
 def array_to_xyz_pointcloud2(cloud_arr, stamp=None, frame_id=None, merge_rgb=False):
-    """ convert an Nx3 float array to an xyz point cloud.
+    """convert an Nx3 float array to an xyz point cloud.
     preserves (scalar) dtype of input.
     TODO: untested
     """
     cloud_arr = np.asarray(cloud_arr)
-    if not cloud_arr.ndim==2: raise ValueError('cloud_arr must be 2D array')
-    if not cloud_arr.shape[1]==3: raise ValueError('cloud_arr shape must be Nx3')
-    xyz = cloud_arr.view(np.dtype([('x', cloud_arr.dtype), ('y', cloud_arr.dtype), ('z', cloud_arr.dtype)])).squeeze()
-    return array_to_pointcloud2(xyz, stamp=stamp, frame_id=frame_id, merge_rgb=merge_rgb)
+    if not cloud_arr.ndim == 2:
+        raise ValueError("cloud_arr must be 2D array")
+    if not cloud_arr.shape[1] == 3:
+        raise ValueError("cloud_arr shape must be Nx3")
+    xyz = cloud_arr.view(
+        np.dtype(
+            [("x", cloud_arr.dtype), ("y", cloud_arr.dtype), ("z", cloud_arr.dtype)]
+        )
+    ).squeeze()
+    return array_to_pointcloud2(
+        xyz, stamp=stamp, frame_id=frame_id, merge_rgb=merge_rgb
+    )
+
 
 def array_to_pointcloud2(cloud_arr, stamp=None, frame_id=None, merge_rgb=False):
-    '''Converts a numpy record array to a sensor_msgs.msg.PointCloud2.
-    '''
+    """Converts a numpy record array to a sensor_msgs.msg.PointCloud2."""
     if merge_rgb:
         cloud_arr = merge_rgb_fields(cloud_arr)
 
@@ -222,23 +292,26 @@ def array_to_pointcloud2(cloud_arr, stamp=None, frame_id=None, merge_rgb=False):
     cloud_msg.height = cloud_arr.shape[0]
     cloud_msg.width = cloud_arr.shape[1]
     cloud_msg.fields = arr_to_fields(cloud_arr)
-    cloud_msg.is_bigendian = False # assumption
+    cloud_msg.is_bigendian = False  # assumption
     cloud_msg.point_step = cloud_arr.dtype.itemsize
-    cloud_msg.row_step = cloud_msg.point_step*cloud_arr.shape[1]
-    cloud_msg.is_dense = all([np.isfinite(cloud_arr[fname]).all() for fname in cloud_arr.dtype.names])
+    cloud_msg.row_step = cloud_msg.point_step * cloud_arr.shape[1]
+    cloud_msg.is_dense = all(
+        [np.isfinite(cloud_arr[fname]).all() for fname in cloud_arr.dtype.names]
+    )
     cloud_msg.data = cloud_arr.tostring()
     return cloud_msg
 
+
 def merge_rgb_fields(cloud_arr):
-    '''Takes an array with named np.uint8 fields 'r', 'g', and 'b', and returns an array in
+    """Takes an array with named np.uint8 fields 'r', 'g', and 'b', and returns an array in
     which they have been merged into a single np.float32 'rgb' field. The first byte of this
     field is the 'r' uint8, the second is the 'g', uint8, and the third is the 'b' uint8.
 
     This is the way that pcl likes to handle RGB colors for some reason.
-    '''
-    r = np.asarray(cloud_arr['r'], dtype=np.uint32)
-    g = np.asarray(cloud_arr['g'], dtype=np.uint32)
-    b = np.asarray(cloud_arr['b'], dtype=np.uint32)
+    """
+    r = np.asarray(cloud_arr["r"], dtype=np.uint32)
+    g = np.asarray(cloud_arr["g"], dtype=np.uint32)
+    b = np.asarray(cloud_arr["b"], dtype=np.uint32)
     rgb_arr = np.array((r << 16) | (g << 8) | (b << 0), dtype=np.uint32)
 
     # not sure if there is a better way to do this. i'm changing the type of the array
@@ -249,27 +322,28 @@ def merge_rgb_fields(cloud_arr):
     new_dtype = []
     for field_name in cloud_arr.dtype.names:
         field_type, field_offset = cloud_arr.dtype.fields[field_name]
-        if field_name not in ('r', 'g', 'b'):
+        if field_name not in ("r", "g", "b"):
             new_dtype.append((field_name, field_type))
-    new_dtype.append(('rgb', np.float32))
+    new_dtype.append(("rgb", np.float32))
     new_cloud_arr = np.zeros(cloud_arr.shape, new_dtype)
 
     # fill in the new array
     for field_name in new_cloud_arr.dtype.names:
-        if field_name == 'rgb':
+        if field_name == "rgb":
             new_cloud_arr[field_name] = rgb_arr
         else:
             new_cloud_arr[field_name] = cloud_arr[field_name]
 
     return new_cloud_arr
 
+
 def split_rgb_field(cloud_arr):
-    '''Takes an array with a named 'rgb' float32 field, and returns an array in which
+    """Takes an array with a named 'rgb' float32 field, and returns an array in which
     this has been split into 3 uint 8 fields: 'r', 'g', and 'b'.
 
     (pcl stores rgb in packed 32 bit floats)
-    '''
-    rgb_arr = cloud_arr['rgb'].copy()
+    """
+    rgb_arr = cloud_arr["rgb"].copy()
     rgb_arr.dtype = np.uint32
     r = np.asarray((rgb_arr >> 16) & 255, dtype=np.uint8)
     g = np.asarray((rgb_arr >> 8) & 255, dtype=np.uint8)
@@ -279,41 +353,47 @@ def split_rgb_field(cloud_arr):
     new_dtype = []
     for field_name in cloud_arr.dtype.names:
         field_type, field_offset = cloud_arr.dtype.fields[field_name]
-        if not field_name == 'rgb':
+        if not field_name == "rgb":
             new_dtype.append((field_name, field_type))
-    new_dtype.append(('r', np.uint8))
-    new_dtype.append(('g', np.uint8))
-    new_dtype.append(('b', np.uint8))
+    new_dtype.append(("r", np.uint8))
+    new_dtype.append(("g", np.uint8))
+    new_dtype.append(("b", np.uint8))
     new_cloud_arr = np.zeros(cloud_arr.shape, new_dtype)
 
     # fill in the new array
     for field_name in new_cloud_arr.dtype.names:
-        if field_name == 'r':
+        if field_name == "r":
             new_cloud_arr[field_name] = r
-        elif field_name == 'g':
+        elif field_name == "g":
             new_cloud_arr[field_name] = g
-        elif field_name == 'b':
+        elif field_name == "b":
             new_cloud_arr[field_name] = b
         else:
             new_cloud_arr[field_name] = cloud_arr[field_name]
     return new_cloud_arr
 
+
 def get_xyz_points(cloud_array, remove_nans=True, dtype=np.float):
-    '''Pulls out x, y, and z columns from the cloud recordarray, and returns
-	a 3xN matrix.
-    '''
+    """Pulls out x, y, and z columns from the cloud recordarray, and returns
+    a 3xN matrix.
+    """
     # remove crap points
     if remove_nans:
-        mask = np.isfinite(cloud_array['x']) & np.isfinite(cloud_array['y']) & np.isfinite(cloud_array['z'])
+        mask = (
+            np.isfinite(cloud_array["x"])
+            & np.isfinite(cloud_array["y"])
+            & np.isfinite(cloud_array["z"])
+        )
         cloud_array = cloud_array[mask]
 
     # pull out x, y, and z values
     points = np.zeros(list(cloud_array.shape) + [3], dtype=dtype)
-    points[...,0] = cloud_array['x']
-    points[...,1] = cloud_array['y']
-    points[...,2] = cloud_array['z']
+    points[..., 0] = cloud_array["x"]
+    points[..., 1] = cloud_array["y"]
+    points[..., 2] = cloud_array["z"]
 
     return points
+
 
 def pointcloud2_to_xyz_array(cloud_msg, remove_nans=True):
     return get_xyz_points(pointcloud2_to_array(cloud_msg))

--- a/pypcd/pdutil.py
+++ b/pypcd/pdutil.py
@@ -1,30 +1,34 @@
 from pypcd import pypcd
-from pypcd import numpy_pc2 
+from pypcd import numpy_pc2
+
+
 def data_frame_to_point_cloud(df):
-    """ create a PointCloud object from a dataframe.
-    """
+    """create a PointCloud object from a dataframe."""
     pc_data = df.to_records(index=False)
-    md = {'version':.7,
-          'fields': [],
-          'size': [],
-          'count': [],
-          'width': 0,
-          'height':1,
-          'viewpoint':[0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0],
-          'points': 0,
-          'type': [],
-          'data':'binary_compressed'}
-    md['fields'] = df.columns.tolist()
-    for field in md['fields']:
-        type_, size_ = pypcd.numpy_type_to_pcd_type[ pc_data.dtype.fields[field][0] ]
-        md['type'].append( type_ )
-        md['size'].append( size_ )
+    md = {
+        "version": 0.7,
+        "fields": [],
+        "size": [],
+        "count": [],
+        "width": 0,
+        "height": 1,
+        "viewpoint": [0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0],
+        "points": 0,
+        "type": [],
+        "data": "binary_compressed",
+    }
+    md["fields"] = df.columns.tolist()
+    for field in md["fields"]:
+        type_, size_ = pypcd.numpy_type_to_pcd_type[pc_data.dtype.fields[field][0]]
+        md["type"].append(type_)
+        md["size"].append(size_)
         # TODO handle multicount
-        md['count'].append( 1 )
-    md['width'] = len(pc_data)
-    md['points'] = len(pc_data)
+        md["count"].append(1)
+    md["width"] = len(pc_data)
+    md["points"] = len(pc_data)
     pc = pypcd.PointCloud(md, pc_data)
     return pc
+
 
 def data_frame_to_message(df, stamp=None, frame_id=None):
     pc_data = df.to_records(index=False)

--- a/pypcd/pypcd.py
+++ b/pypcd/pypcd.py
@@ -28,7 +28,7 @@ __all__ = ['PointCloud',
            'point_cloud_to_buffer',
            'point_cloud_to_fileobj',
            'point_cloud_from_path',
-           'pandas_to_pypc',
+           'pandas_to_pypcd',
            'point_cloud_from_buffer',
            'point_cloud_from_fileobj',
            'make_xyz_point_cloud',
@@ -295,7 +295,7 @@ def point_cloud_from_path(fname):
         pc = point_cloud_from_fileobj(f)
     return pc
 
-def pandas_to_pypc(df):
+def pandas_to_pypcd(df):
     """ Convert pandas dataframe to a pypcd point cloud
     :param df: input dataframe with desired columns. Datatypes and column names will be converted directly
     """

--- a/pypcd/pypcd.py
+++ b/pypcd/pypcd.py
@@ -13,6 +13,7 @@ import copy
 from io import StringIO as sio
 import numpy as np
 import warnings
+import pandas as pd
 import lzf
 
 HAS_SENSOR_MSGS = True
@@ -27,6 +28,7 @@ __all__ = ['PointCloud',
            'point_cloud_to_buffer',
            'point_cloud_to_fileobj',
            'point_cloud_from_path',
+           'pandas_to_pypc',
            'point_cloud_from_buffer',
            'point_cloud_from_fileobj',
            'make_xyz_point_cloud',
@@ -292,6 +294,28 @@ def point_cloud_from_path(fname):
     with open(fname, 'rb') as f:
         pc = point_cloud_from_fileobj(f)
     return pc
+
+def pandas_to_pypc(df):
+    """ Convert pandas dataframe to a pypcd point cloud
+    :param df: input dataframe with desired columns. Datatypes and column names will be converted directly
+    """
+    pc_data = df.to_records(index=False)
+    md = { 'version':.7,
+        'fields': [], 'size': [], 'count': [],
+        'width': 0, 'height':1,
+        'viewpoint':[0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0],
+        'points': 0, 'type': [], 'data':'binary_compressed'
+    }
+    md['fields'] = df.columns.tolist()
+    for field in md['fields']:
+        type_, size_ = numpy_type_to_pcd_type[ pc_data.dtype.fields[field][0] ]
+        md['type'].append( type_ )
+        md['size'].append( size_ )
+        md['count'].append( 1 )
+    md['width'] = len(pc_data)
+    md['points'] = len(pc_data)
+
+    return PointCloud(md, pc_data)
 
 
 def point_cloud_from_buffer(buf):

--- a/pypcd/pypcd.py
+++ b/pypcd/pypcd.py
@@ -79,11 +79,19 @@ def parse_header(lines):
     for ln in lines:
         if ln.startswith('#') or len(ln) < 2:
             continue
-        match = re.match('(\w+)\s+([\w\s\.]+)', ln)
-        if not match:
+
+        values = ln.split()
+
+        # First word is the key
+        key = values[0].lower()
+
+        # Remaining words, space delimited, are the values
+        value = " ".join(values[1:])
+
+        if len(values) < 2:
             warnings.warn("warning: can't understand line: %s" % ln)
             continue
-        key, value = match.group(1).lower(), match.group(2)
+
         if key == 'version':
             metadata[key] = value
         elif key in ('fields', 'type'):

--- a/pypcd/pypcd.py
+++ b/pypcd/pypcd.py
@@ -253,7 +253,7 @@ def parse_binary_pc_data(f, dtype, metadata):
     rowstep = metadata["points"] * dtype.itemsize
     # for some reason pcl adds empty space at the end of files
     buf = f.read(rowstep)
-    return np.fromstring(buf, dtype=dtype)
+    return np.frombuffer(buf, dtype=dtype)
 
 
 def parse_binary_compressed_pc_data(f, dtype, metadata):
@@ -278,7 +278,7 @@ def parse_binary_compressed_pc_data(f, dtype, metadata):
     for dti in range(len(dtype)):
         dt = dtype[dti]
         bytes = dt.itemsize * metadata["width"]
-        column = np.fromstring(buf[ix : (ix + bytes)], dt)
+        column = np.frombuffer(buf[ix : (ix + bytes)], dt)
         pc_data[dtype.names[dti]] = column
         ix += bytes
     return pc_data

--- a/pypcd/pypcd.py
+++ b/pypcd/pypcd.py
@@ -23,53 +23,58 @@ try:
 except ImportError:
     HAS_SENSOR_MSGS = False
 
-__all__ = ['PointCloud',
-           'point_cloud_to_path',
-           'point_cloud_to_buffer',
-           'point_cloud_to_fileobj',
-           'point_cloud_from_path',
-           'pandas_to_pypcd',
-           'point_cloud_from_buffer',
-           'point_cloud_from_fileobj',
-           'make_xyz_point_cloud',
-           'make_xyz_rgb_point_cloud',
-           'make_xyz_label_point_cloud',
-           'save_txt',
-           'cat_point_clouds',
-           'add_fields',
-           'update_field',
-           'build_ascii_fmtstr',
-           'encode_rgb_for_pcl',
-           'decode_rgb_from_pcl',
-           'save_point_cloud',
-           'save_point_cloud_bin',
-           'save_point_cloud_bin_compressed',
-           'pcd_type_to_numpy_type',
-           'numpy_type_to_pcd_type',
-           ]
+__all__ = [
+    "PointCloud",
+    "point_cloud_to_path",
+    "point_cloud_to_buffer",
+    "point_cloud_to_fileobj",
+    "point_cloud_from_path",
+    "pandas_to_pypcd",
+    "point_cloud_from_buffer",
+    "point_cloud_from_fileobj",
+    "make_xyz_point_cloud",
+    "make_xyz_rgb_point_cloud",
+    "make_xyz_label_point_cloud",
+    "save_txt",
+    "cat_point_clouds",
+    "add_fields",
+    "update_field",
+    "build_ascii_fmtstr",
+    "encode_rgb_for_pcl",
+    "decode_rgb_from_pcl",
+    "save_point_cloud",
+    "save_point_cloud_bin",
+    "save_point_cloud_bin_compressed",
+    "pcd_type_to_numpy_type",
+    "numpy_type_to_pcd_type",
+]
 
 if HAS_SENSOR_MSGS:
-    pc2_pcd_type_mappings = [(PointField.INT8, ('I', 1)),
-                             (PointField.UINT8, ('U', 1)),
-                             (PointField.INT16, ('I', 2)),
-                             (PointField.UINT16, ('U', 2)),
-                             (PointField.INT32, ('I', 4)),
-                             (PointField.UINT32, ('U', 4)),
-                             (PointField.FLOAT32, ('F', 4)),
-                             (PointField.FLOAT64, ('F', 8))]
+    pc2_pcd_type_mappings = [
+        (PointField.INT8, ("I", 1)),
+        (PointField.UINT8, ("U", 1)),
+        (PointField.INT16, ("I", 2)),
+        (PointField.UINT16, ("U", 2)),
+        (PointField.INT32, ("I", 4)),
+        (PointField.UINT32, ("U", 4)),
+        (PointField.FLOAT32, ("F", 4)),
+        (PointField.FLOAT64, ("F", 8)),
+    ]
     pc2_type_to_pcd_type = dict(pc2_pcd_type_mappings)
     pcd_type_to_pc2_type = dict((q, p) for (p, q) in pc2_pcd_type_mappings)
-    __all__.extend(['pcd_type_to_pc2_type', 'pc2_type_to_pcd_type'])
+    __all__.extend(["pcd_type_to_pc2_type", "pc2_type_to_pcd_type"])
 
-numpy_pcd_type_mappings = [(np.dtype('float32'), ('F', 4)),
-                           (np.dtype('float64'), ('F', 8)),
-                           (np.dtype('uint8'), ('U', 1)),
-                           (np.dtype('uint16'), ('U', 2)),
-                           (np.dtype('uint32'), ('U', 4)),
-                           (np.dtype('uint64'), ('U', 8)),
-                           (np.dtype('int16'), ('I', 2)),
-                           (np.dtype('int32'), ('I', 4)),
-                           (np.dtype('int64'), ('I', 8))]
+numpy_pcd_type_mappings = [
+    (np.dtype("float32"), ("F", 4)),
+    (np.dtype("float64"), ("F", 8)),
+    (np.dtype("uint8"), ("U", 1)),
+    (np.dtype("uint16"), ("U", 2)),
+    (np.dtype("uint32"), ("U", 4)),
+    (np.dtype("uint64"), ("U", 8)),
+    (np.dtype("int16"), ("I", 2)),
+    (np.dtype("int32"), ("I", 4)),
+    (np.dtype("int64"), ("I", 8)),
+]
 numpy_type_to_pcd_type = dict(numpy_pcd_type_mappings)
 pcd_type_to_numpy_type = dict((q, p) for (p, q) in numpy_pcd_type_mappings)
 
@@ -77,7 +82,7 @@ pcd_type_to_numpy_type = dict((q, p) for (p, q) in numpy_pcd_type_mappings)
 def parse_header(lines):
     metadata = {}
     for ln in lines:
-        if ln.startswith('#') or len(ln) < 2:
+        if ln.startswith("#") or len(ln) < 2:
             continue
 
         values = ln.split()
@@ -92,32 +97,31 @@ def parse_header(lines):
             warnings.warn("warning: can't understand line: %s" % ln)
             continue
 
-        if key == 'version':
+        if key == "version":
             metadata[key] = value
-        elif key in ('fields', 'type'):
+        elif key in ("fields", "type"):
             metadata[key] = value.split()
-        elif key in ('size', 'count'):
+        elif key in ("size", "count"):
             metadata[key] = list(map(int, value.split()))
-        elif key in ('width', 'height', 'points'):
+        elif key in ("width", "height", "points"):
             metadata[key] = int(value)
-        elif key == 'viewpoint':
+        elif key == "viewpoint":
             metadata[key] = list(map(float, value.split()))
-        elif key == 'data':
+        elif key == "data":
             metadata[key] = value.strip().lower()
         # TODO apparently count is not required?
     # add some reasonable defaults
-    if 'count' not in metadata:
-        metadata['count'] = [1]*len(metadata['fields'])
-    if 'viewpoint' not in metadata:
-        metadata['viewpoint'] = [0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0]
-    if 'version' not in metadata:
-        metadata['version'] = '.7'
+    if "count" not in metadata:
+        metadata["count"] = [1] * len(metadata["fields"])
+    if "viewpoint" not in metadata:
+        metadata["viewpoint"] = [0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0]
+    if "version" not in metadata:
+        metadata["version"] = ".7"
     return metadata
 
 
 def write_header(metadata, rename_padding=False):
-    """ given metadata as dictionary return a string header.
-    """
+    """given metadata as dictionary return a string header."""
     template = """\
 VERSION {version}
 FIELDS {fields}
@@ -133,56 +137,65 @@ DATA {data}
     str_metadata = metadata.copy()
 
     if not rename_padding:
-        str_metadata['fields'] = ' '.join(metadata['fields'])
+        str_metadata["fields"] = " ".join(metadata["fields"])
     else:
         new_fields = []
-        for f in metadata['fields']:
-            if f == '_':
-                new_fields.append('padding')
+        for f in metadata["fields"]:
+            if f == "_":
+                new_fields.append("padding")
             else:
                 new_fields.append(f)
-        str_metadata['fields'] = ' '.join(new_fields)
-    str_metadata['size'] = ' '.join(map(str, metadata['size']))
-    str_metadata['type'] = ' '.join(metadata['type'])
-    str_metadata['count'] = ' '.join(map(str, metadata['count']))
-    str_metadata['width'] = str(metadata['width'])
-    str_metadata['height'] = str(metadata['height'])
-    str_metadata['viewpoint'] = ' '.join(map(str, metadata['viewpoint']))
-    str_metadata['points'] = str(metadata['points'])
+        str_metadata["fields"] = " ".join(new_fields)
+    str_metadata["size"] = " ".join(map(str, metadata["size"]))
+    str_metadata["type"] = " ".join(metadata["type"])
+    str_metadata["count"] = " ".join(map(str, metadata["count"]))
+    str_metadata["width"] = str(metadata["width"])
+    str_metadata["height"] = str(metadata["height"])
+    str_metadata["viewpoint"] = " ".join(map(str, metadata["viewpoint"]))
+    str_metadata["points"] = str(metadata["points"])
     tmpl = template.format(**str_metadata)
     return tmpl
 
 
 def _metadata_is_consistent(metadata):
-    """ sanity check for metadata. just some basic checks.
-    """
+    """sanity check for metadata. just some basic checks."""
     checks = []
-    required = ('version', 'fields', 'size', 'width', 'height', 'points',
-                'viewpoint', 'data')
+    required = (
+        "version",
+        "fields",
+        "size",
+        "width",
+        "height",
+        "points",
+        "viewpoint",
+        "data",
+    )
     for f in required:
         if f not in metadata:
-            print('%s required' % f)
-    checks.append((lambda m: all([k in m for k in required]),
-                   'missing field'))
-    checks.append((lambda m: len(m['type']) == len(m['count']) ==
-                   len(m['fields']),
-                   'length of type, count and fields must be equal'))
-    checks.append((lambda m: m['height'] > 0,
-                   'height must be greater than 0'))
-    checks.append((lambda m: m['width'] > 0,
-                   'width must be greater than 0'))
-    checks.append((lambda m: m['points'] > 0,
-                   'points must be greater than 0'))
-    checks.append((lambda m: m['data'].lower() in ('ascii', 'binary',
-                   'binary_compressed'),
-                   'unknown data type:'
-                   'should be ascii/binary/binary_compressed'))
+            print("%s required" % f)
+    checks.append((lambda m: all([k in m for k in required]), "missing field"))
+    checks.append(
+        (
+            lambda m: len(m["type"]) == len(m["count"]) == len(m["fields"]),
+            "length of type, count and fields must be equal",
+        )
+    )
+    checks.append((lambda m: m["height"] > 0, "height must be greater than 0"))
+    checks.append((lambda m: m["width"] > 0, "width must be greater than 0"))
+    checks.append((lambda m: m["points"] > 0, "points must be greater than 0"))
+    checks.append(
+        (
+            lambda m: m["data"].lower() in ("ascii", "binary", "binary_compressed"),
+            "unknown data type:" "should be ascii/binary/binary_compressed",
+        )
+    )
     ok = True
     for check, msg in checks:
         if not check(metadata):
-            print('error:', msg)
+            print("error:", msg)
             ok = False
     return ok
+
 
 # def pcd_type_to_numpy(pcd_type, pcd_sz):
 #     """ convert from a pcd type string and size to numpy dtype."""
@@ -193,52 +206,51 @@ def _metadata_is_consistent(metadata):
 
 
 def _build_dtype(metadata):
-    """ build numpy structured array dtype from pcl metadata.
+    """build numpy structured array dtype from pcl metadata.
     note that fields with count > 1 are 'flattened' by creating multiple
     single-count fields.
     TODO: allow 'proper' multi-count fields.
     """
     fieldnames = []
     typenames = []
-    for f, c, t, s in zip(metadata['fields'],
-                          metadata['count'],
-                          metadata['type'],
-                          metadata['size']):
+    for f, c, t, s in zip(
+        metadata["fields"], metadata["count"], metadata["type"], metadata["size"]
+    ):
         np_type = pcd_type_to_numpy_type[(t, s)]
         if c == 1:
             fieldnames.append(f)
             typenames.append(np_type)
         else:
-            fieldnames.extend(['%s_%04d' % (f, i) for i in range(c)])
-            typenames.extend([np_type]*c)
+            fieldnames.extend(["%s_%04d" % (f, i) for i in range(c)])
+            typenames.extend([np_type] * c)
     dtype = np.dtype(list(zip(fieldnames, typenames)))
     return dtype
 
 
 def build_ascii_fmtstr(pc):
-    """ make a format string for printing to ascii, using fields
+    """make a format string for printing to ascii, using fields
     %.8f minimum for rgb
     %.10f for more general use?
     """
     fmtstr = []
     for t, cnt in zip(pc.type, pc.count):
-        if t == 'F':
-            fmtstr.extend(['%.10f']*cnt)
-        elif t == 'I':
-            fmtstr.extend(['%d']*cnt)
-        elif t == 'U':
-            fmtstr.extend(['%u']*cnt)
+        if t == "F":
+            fmtstr.extend(["%.10f"] * cnt)
+        elif t == "I":
+            fmtstr.extend(["%d"] * cnt)
+        elif t == "U":
+            fmtstr.extend(["%u"] * cnt)
         else:
             raise ValueError("don't know about type %s" % t)
     return fmtstr
 
 
 def parse_ascii_pc_data(f, dtype, metadata):
-    return np.loadtxt(f, dtype=dtype, delimiter=' ')
+    return np.loadtxt(f, dtype=dtype, delimiter=" ")
 
 
 def parse_binary_pc_data(f, dtype, metadata):
-    rowstep = metadata['points']*dtype.itemsize
+    rowstep = metadata["points"] * dtype.itemsize
     # for some reason pcl adds empty space at the end of files
     buf = f.read(rowstep)
     return np.fromstring(buf, dtype=dtype)
@@ -249,79 +261,87 @@ def parse_binary_compressed_pc_data(f, dtype, metadata):
     # uncompressed size of data (uint32)
     # compressed data
     # junk
-    fmt = 'II'
-    compressed_size, uncompressed_size =\
-        struct.unpack(fmt, f.read(struct.calcsize(fmt)))
+    fmt = "II"
+    compressed_size, uncompressed_size = struct.unpack(
+        fmt, f.read(struct.calcsize(fmt))
+    )
     compressed_data = f.read(compressed_size)
     # TODO what to use as second argument? if buf is None
     # (compressed > uncompressed)
     # should we read buf as raw binary?
     buf = lzf.decompress(compressed_data, uncompressed_size)
     if len(buf) != uncompressed_size:
-        raise Exception('Error decompressing data')
+        raise Exception("Error decompressing data")
     # the data is stored field-by-field
-    pc_data = np.zeros(metadata['width'], dtype=dtype)
+    pc_data = np.zeros(metadata["width"], dtype=dtype)
     ix = 0
     for dti in range(len(dtype)):
         dt = dtype[dti]
-        bytes = dt.itemsize * metadata['width']
-        column = np.fromstring(buf[ix:(ix+bytes)], dt)
+        bytes = dt.itemsize * metadata["width"]
+        column = np.fromstring(buf[ix : (ix + bytes)], dt)
         pc_data[dtype.names[dti]] = column
         ix += bytes
     return pc_data
 
 
 def point_cloud_from_fileobj(f):
-    """ parse pointcloud coming from file object f
-    """
+    """parse pointcloud coming from file object f"""
     header = []
     while True:
         ln = f.readline().strip()
         if not isinstance(ln, str):
-            ln = ln.decode('utf-8')
+            ln = ln.decode("utf-8")
         header.append(ln)
-        if ln.startswith('DATA'):
+        if ln.startswith("DATA"):
             metadata = parse_header(header)
             dtype = _build_dtype(metadata)
             break
-    if metadata['data'] == 'ascii':
+    if metadata["data"] == "ascii":
         pc_data = parse_ascii_pc_data(f, dtype, metadata)
-    elif metadata['data'] == 'binary':
+    elif metadata["data"] == "binary":
         pc_data = parse_binary_pc_data(f, dtype, metadata)
-    elif metadata['data'] == 'binary_compressed':
+    elif metadata["data"] == "binary_compressed":
         pc_data = parse_binary_compressed_pc_data(f, dtype, metadata)
     else:
-        print('DATA field is neither "ascii" or "binary" or\
-                "binary_compressed"')
+        print(
+            'DATA field is neither "ascii" or "binary" or\
+                "binary_compressed"'
+        )
     return PointCloud(metadata, pc_data)
 
 
 def point_cloud_from_path(fname):
-    """ load point cloud in binary format
-    """
-    with open(fname, 'rb') as f:
+    """load point cloud in binary format"""
+    with open(fname, "rb") as f:
         pc = point_cloud_from_fileobj(f)
     return pc
 
+
 def pandas_to_pypcd(df):
-    """ Convert pandas dataframe to a pypcd point cloud
+    """Convert pandas dataframe to a pypcd point cloud
     :param df: input dataframe with desired columns. Datatypes and column names will be converted directly
     """
     pc_data = df.to_records(index=False)
-    md = { 'version':.7,
-        'fields': [], 'size': [], 'count': [],
-        'width': 0, 'height':1,
-        'viewpoint':[0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0],
-        'points': 0, 'type': [], 'data':'binary_compressed'
+    md = {
+        "version": 0.7,
+        "fields": [],
+        "size": [],
+        "count": [],
+        "width": 0,
+        "height": 1,
+        "viewpoint": [0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0],
+        "points": 0,
+        "type": [],
+        "data": "binary_compressed",
     }
-    md['fields'] = df.columns.tolist()
-    for field in md['fields']:
-        type_, size_ = numpy_type_to_pcd_type[ pc_data.dtype.fields[field][0] ]
-        md['type'].append( type_ )
-        md['size'].append( size_ )
-        md['count'].append( 1 )
-    md['width'] = len(pc_data)
-    md['points'] = len(pc_data)
+    md["fields"] = df.columns.tolist()
+    for field in md["fields"]:
+        type_, size_ = numpy_type_to_pcd_type[pc_data.dtype.fields[field][0]]
+        md["type"].append(type_)
+        md["size"].append(size_)
+        md["count"].append(1)
+    md["width"] = len(pc_data)
+    md["points"] = len(pc_data)
 
     return PointCloud(md, pc_data)
 
@@ -334,23 +354,23 @@ def point_cloud_from_buffer(buf):
 
 
 def point_cloud_to_fileobj(pc, fileobj, data_compression=None):
-    """ write pointcloud as .pcd to fileobj.
+    """write pointcloud as .pcd to fileobj.
     if data_compression is not None it overrides pc.data.
     """
     metadata = pc.get_metadata()
     if data_compression is not None:
         data_compression = data_compression.lower()
-        assert(data_compression in ('ascii', 'binary', 'binary_compressed'))
-        metadata['data'] = data_compression
+        assert data_compression in ("ascii", "binary", "binary_compressed")
+        metadata["data"] = data_compression
 
-    header = write_header(metadata).encode('utf-8')
+    header = write_header(metadata).encode("utf-8")
     fileobj.write(header)
-    if metadata['data'].lower() == 'ascii':
+    if metadata["data"].lower() == "ascii":
         fmtstr = build_ascii_fmtstr(pc)
         np.savetxt(fileobj, pc.pc_data, fmt=fmtstr)
-    elif metadata['data'].lower() == 'binary':
+    elif metadata["data"].lower() == "binary":
         fileobj.write(pc.pc_data.tostring())
-    elif metadata['data'].lower() == 'binary_compressed':
+    elif metadata["data"].lower() == "binary_compressed":
         # TODO
         # a '_' field is ignored by pcl and breakes compressed point clouds.
         # changing '_' to '_padding' or other name fixes this.
@@ -360,7 +380,7 @@ def point_cloud_to_fileobj(pc, fileobj, data_compression=None):
         for fieldname in pc.pc_data.dtype.names:
             column = np.ascontiguousarray(pc.pc_data[fieldname]).tostring()
             uncompressed_lst.append(column)
-        uncompressed = b''.join(uncompressed_lst)
+        uncompressed = b"".join(uncompressed_lst)
         uncompressed_size = len(uncompressed)
         # print("uncompressed_size = %r"%(uncompressed_size))
         buf = lzf.compress(uncompressed)
@@ -371,16 +391,16 @@ def point_cloud_to_fileobj(pc, fileobj, data_compression=None):
             compressed_size = uncompressed_size
         else:
             compressed_size = len(buf)
-        fmt = 'II'
+        fmt = "II"
         fileobj.write(struct.pack(fmt, compressed_size, uncompressed_size))
         fileobj.write(buf)
     else:
-        raise ValueError('unknown DATA type')
+        raise ValueError("unknown DATA type")
     # we can't close because if it's stringio buf then we can't get value after
 
 
 def point_cloud_to_path(pc, fname):
-    with open(fname, 'w') as f:
+    with open(fname, "w") as f:
         point_cloud_to_fileobj(pc, f)
 
 
@@ -391,60 +411,59 @@ def point_cloud_to_buffer(pc, data_compression=None):
 
 
 def save_point_cloud(pc, fname):
-    """ save pointcloud to fname in ascii format
-    """
-    with open(fname, 'wb') as f:
-        point_cloud_to_fileobj(pc, f, 'ascii')
+    """save pointcloud to fname in ascii format"""
+    with open(fname, "wb") as f:
+        point_cloud_to_fileobj(pc, f, "ascii")
 
 
 def save_point_cloud_bin(pc, fname):
-    """ save pointcloud to fname in binary format
-    """
-    with open(fname, 'wb') as f:
-        point_cloud_to_fileobj(pc, f, 'binary')
+    """save pointcloud to fname in binary format"""
+    with open(fname, "wb") as f:
+        point_cloud_to_fileobj(pc, f, "binary")
 
 
 def save_point_cloud_bin_compressed(pc, fname):
-    with open(fname, 'wb') as f:
-        point_cloud_to_fileobj(pc, f, 'binary_compressed')
+    with open(fname, "wb") as f:
+        point_cloud_to_fileobj(pc, f, "binary_compressed")
 
 
 def save_xyz_label(pc, fname, use_default_lbl=False):
-    """ save a simple (x y z label) pointcloud, ignoring all other features.
+    """save a simple (x y z label) pointcloud, ignoring all other features.
     label is initialized to 1000, for jptview.
     """
     md = pc.get_metadata()
-    if not use_default_lbl and ('label' not in md['fields']):
-        raise Exception('label is not a field in this point cloud')
-    with open(fname, 'w') as f:
+    if not use_default_lbl and ("label" not in md["fields"]):
+        raise Exception("label is not a field in this point cloud")
+    with open(fname, "w") as f:
         for i in xrange(pc.points):
-            x, y, z = ['%.4f' % d for d in (
-                pc.pc_data['x'][i], pc.pc_data['y'][i], pc.pc_data['z'][i]
-                )]
-            lbl = '1000' if use_default_lbl else pc.pc_data['label'][i]
-            f.write(' '.join((x, y, z, lbl))+'\n')
+            x, y, z = [
+                "%.4f" % d
+                for d in (pc.pc_data["x"][i], pc.pc_data["y"][i], pc.pc_data["z"][i])
+            ]
+            lbl = "1000" if use_default_lbl else pc.pc_data["label"][i]
+            f.write(" ".join((x, y, z, lbl)) + "\n")
 
 
 def save_xyz_intensity_label(pc, fname, use_default_lbl=False):
     md = pc.get_metadata()
-    if not use_default_lbl and ('label' not in md['fields']):
-        raise Exception('label is not a field in this point cloud')
-    if 'intensity' not in md['fields']:
-        raise Exception('intensity is not a field in this point cloud')
-    with open(fname, 'w') as f:
+    if not use_default_lbl and ("label" not in md["fields"]):
+        raise Exception("label is not a field in this point cloud")
+    if "intensity" not in md["fields"]:
+        raise Exception("intensity is not a field in this point cloud")
+    with open(fname, "w") as f:
         for i in xrange(pc.points):
-            x, y, z = ['%.4f' % d for d in (
-                pc.pc_data['x'][i], pc.pc_data['y'][i], pc.pc_data['z'][i]
-                )]
-            intensity = '%.4f' % pc.pc_data['intensity'][i]
-            lbl = '1000' if use_default_lbl else pc.pc_data['label'][i]
-            f.write(' '.join((x, y, z, intensity, lbl))+'\n')
+            x, y, z = [
+                "%.4f" % d
+                for d in (pc.pc_data["x"][i], pc.pc_data["y"][i], pc.pc_data["z"][i])
+            ]
+            intensity = "%.4f" % pc.pc_data["intensity"][i]
+            lbl = "1000" if use_default_lbl else pc.pc_data["label"][i]
+            f.write(" ".join((x, y, z, intensity, lbl)) + "\n")
 
 
 def save_txt(pc, fname, header=True):
-    """ TODO support multi-count fields
-    """
-    with open(fname, 'w') as f:
+    """TODO support multi-count fields"""
+    with open(fname, "w") as f:
         if header:
             header_lst = []
             for field_name, cnt in zip(pc.fields, pc.count):
@@ -452,53 +471,50 @@ def save_txt(pc, fname, header=True):
                     header_lst.append(field_name)
                 else:
                     for c in xrange(cnt):
-                        header_lst.append('%s_%04d' % (field_name, c))
-            f.write(' '.join(header_lst)+'\n')
+                        header_lst.append("%s_%04d" % (field_name, c))
+            f.write(" ".join(header_lst) + "\n")
         fmtstr = build_ascii_fmtstr(pc)
         np.savetxt(f, pc.pc_data, fmt=fmtstr)
 
 
 def update_field(pc, field, pc_data):
-    """ updates field in-place.
-    """
+    """updates field in-place."""
     pc.pc_data[field] = pc_data
     return pc
 
 
 def add_fields(pc, metadata, pc_data):
-    """ builds copy of pointcloud with extra fields
+    """builds copy of pointcloud with extra fields
     multi-count fields are sketchy
     """
-    if len(set(metadata['fields']).intersection(set(pc.fields))) > 0:
+    if len(set(metadata["fields"]).intersection(set(pc.fields))) > 0:
         raise Exception("Fields with that name exist.")
 
     if pc.points != len(pc_data):
         raise Exception("Mismatch in number of points.")
 
     new_metadata = pc.get_metadata()
-    new_metadata['fields'].extend(metadata['fields'])
-    new_metadata['count'].extend(metadata['count'])
-    new_metadata['size'].extend(metadata['size'])
-    new_metadata['type'].extend(metadata['type'])
+    new_metadata["fields"].extend(metadata["fields"])
+    new_metadata["count"].extend(metadata["count"])
+    new_metadata["size"].extend(metadata["size"])
+    new_metadata["type"].extend(metadata["type"])
 
     # parse metadata to add
     # TODO factor this
     fieldnames, typenames = [], []
-    for f, c, t, s in zip(metadata['fields'],
-                          metadata['count'],
-                          metadata['type'],
-                          metadata['size']):
+    for f, c, t, s in zip(
+        metadata["fields"], metadata["count"], metadata["type"], metadata["size"]
+    ):
         np_type = pcd_type_to_numpy_type[(t, s)]
         if c == 1:
             fieldnames.append(f)
             typenames.append(np_type)
         else:
-            fieldnames.extend(['%s_%04d' % (f, i) for i in xrange(c)])
-            typenames.extend([np_type]*c)
+            fieldnames.extend(["%s_%04d" % (f, i) for i in xrange(c)])
+            typenames.extend([np_type] * c)
     dtype = list(zip(fieldnames, typenames))
     # new dtype. could be inferred?
-    new_dtype = [(f, pc.pc_data.dtype[f])
-                 for f in pc.pc_data.dtype.names] + dtype
+    new_dtype = [(f, pc.pc_data.dtype[f]) for f in pc.pc_data.dtype.names] + dtype
 
     new_data = np.empty(len(pc.pc_data), new_dtype)
     for n in pc.pc_data.dtype.names:
@@ -518,32 +534,34 @@ def cat_point_clouds(pc1, pc2):
     new_metadata = pc1.get_metadata()
     new_data = np.concatenate((pc1.pc_data, pc2.pc_data))
     # TODO this only makes sense for unstructured pc?
-    new_metadata['width'] = pc1.width+pc2.width
-    new_metadata['points'] = pc1.points+pc2.points
+    new_metadata["width"] = pc1.width + pc2.width
+    new_metadata["points"] = pc1.points + pc2.points
     pc3 = PointCloud(new_metadata, new_data)
     return pc3
 
 
 def make_xyz_point_cloud(xyz, metadata=None):
-    """ Make a pointcloud object from xyz array.
+    """Make a pointcloud object from xyz array.
     xyz array is cast to float32.
     """
-    md = {'version': .7,
-          'fields': ['x', 'y', 'z'],
-          'size': [4, 4, 4],
-          'type': ['F', 'F', 'F'],
-          'count': [1, 1, 1],
-          'width': len(xyz),
-          'height': 1,
-          'viewpoint': [0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0],
-          'points': len(xyz),
-          'data': 'binary'}
+    md = {
+        "version": 0.7,
+        "fields": ["x", "y", "z"],
+        "size": [4, 4, 4],
+        "type": ["F", "F", "F"],
+        "count": [1, 1, 1],
+        "width": len(xyz),
+        "height": 1,
+        "viewpoint": [0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0],
+        "points": len(xyz),
+        "data": "binary",
+    }
     if metadata is not None:
         md.update(metadata)
     xyz = xyz.astype(np.float32)
-    pc_data = xyz.view(np.dtype([('x', np.float32),
-                                 ('y', np.float32),
-                                 ('z', np.float32)]))
+    pc_data = xyz.view(
+        np.dtype([("x", np.float32), ("y", np.float32), ("z", np.float32)])
+    )
     # pc_data = np.rec.fromarrays([xyz[:,0], xyz[:,1], xyz[:,2]], dtype=dt)
     # data = np.rec.fromarrays([xyz.T], dtype=dt)
     pc = PointCloud(md, pc_data)
@@ -551,28 +569,36 @@ def make_xyz_point_cloud(xyz, metadata=None):
 
 
 def make_xyz_rgb_point_cloud(xyz_rgb, metadata=None):
-    """ Make a pointcloud object from xyz array.
+    """Make a pointcloud object from xyz array.
     xyz array is assumed to be float32.
     rgb is assumed to be encoded as float32 according to pcl conventions.
     """
-    md = {'version': .7,
-          'fields': ['x', 'y', 'z', 'rgb'],
-          'count': [1, 1, 1, 1],
-          'width': len(xyz_rgb),
-          'height': 1,
-          'viewpoint': [0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0],
-          'points': len(xyz_rgb),
-          'type': ['F', 'F', 'F', 'F'],
-          'size': [4, 4, 4, 4],
-          'data': 'binary'}
+    md = {
+        "version": 0.7,
+        "fields": ["x", "y", "z", "rgb"],
+        "count": [1, 1, 1, 1],
+        "width": len(xyz_rgb),
+        "height": 1,
+        "viewpoint": [0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0],
+        "points": len(xyz_rgb),
+        "type": ["F", "F", "F", "F"],
+        "size": [4, 4, 4, 4],
+        "data": "binary",
+    }
     if xyz_rgb.dtype != np.float32:
-        raise ValueError('array must be float32')
+        raise ValueError("array must be float32")
     if metadata is not None:
         md.update(metadata)
-    pc_data = xyz_rgb.view(np.dtype([('x', np.float32),
-                                     ('y', np.float32),
-                                     ('z', np.float32),
-                                     ('rgb', np.float32)])).squeeze()
+    pc_data = xyz_rgb.view(
+        np.dtype(
+            [
+                ("x", np.float32),
+                ("y", np.float32),
+                ("z", np.float32),
+                ("rgb", np.float32),
+            ]
+        )
+    ).squeeze()
     # pc_data = np.rec.fromarrays([xyz[:,0], xyz[:,1], xyz[:,2]], dtype=dt)
     # data = np.rec.fromarrays([xyz.T], dtype=dt)
     pc = PointCloud(md, pc_data)
@@ -580,15 +606,16 @@ def make_xyz_rgb_point_cloud(xyz_rgb, metadata=None):
 
 
 def encode_rgb_for_pcl(rgb):
-    """ Input is Nx3 uint8 array with RGB values.
+    """Input is Nx3 uint8 array with RGB values.
     Output is Nx1 float32 array with bit-packed RGB, for PCL.
     """
-    assert(rgb.dtype == np.uint8)
-    assert(rgb.ndim == 2)
-    assert(rgb.shape[1] == 3)
+    assert rgb.dtype == np.uint8
+    assert rgb.ndim == 2
+    assert rgb.shape[1] == 3
     rgb = rgb.astype(np.uint32)
-    rgb = np.array((rgb[:, 0] << 16) | (rgb[:, 1] << 8) | (rgb[:, 2] << 0),
-                   dtype=np.uint32)
+    rgb = np.array(
+        (rgb[:, 0] << 16) | (rgb[:, 1] << 8) | (rgb[:, 2] << 0), dtype=np.uint32
+    )
     rgb.dtype = np.float32
     return rgb
 
@@ -606,30 +633,34 @@ def decode_rgb_from_pcl(rgb):
     return rgb_arr
 
 
-def make_xyz_label_point_cloud(xyzl, label_type='f'):
-    """ TODO i labels? """
-    md = {'version': .7,
-          'fields': ['x', 'y', 'z', 'label'],
-          'count': [1, 1, 1, 1],
-          'width': len(xyzl),
-          'height': 1,
-          'viewpoint': [0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0],
-          'points': len(xyzl),
-          'data': 'ASCII'}
-    if label_type.lower() == 'f':
-        md['size'] = [4, 4, 4, 4]
-        md['type'] = ['F', 'F', 'F', 'F']
-    elif label_type.lower() == 'u':
-        md['size'] = [4, 4, 4, 1]
-        md['type'] = ['F', 'F', 'F', 'U']
+def make_xyz_label_point_cloud(xyzl, label_type="f"):
+    """TODO i labels?"""
+    md = {
+        "version": 0.7,
+        "fields": ["x", "y", "z", "label"],
+        "count": [1, 1, 1, 1],
+        "width": len(xyzl),
+        "height": 1,
+        "viewpoint": [0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0],
+        "points": len(xyzl),
+        "data": "ASCII",
+    }
+    if label_type.lower() == "f":
+        md["size"] = [4, 4, 4, 4]
+        md["type"] = ["F", "F", "F", "F"]
+    elif label_type.lower() == "u":
+        md["size"] = [4, 4, 4, 1]
+        md["type"] = ["F", "F", "F", "U"]
     else:
-        raise ValueError('label type must be F or U')
+        raise ValueError("label type must be F or U")
     # TODO use .view()
     xyzl = xyzl.astype(np.float32)
-    dt = np.dtype([('x', np.float32), ('y', np.float32), ('z', np.float32),
-                   ('label', np.float32)])
-    pc_data = np.rec.fromarrays([xyzl[:, 0], xyzl[:, 1], xyzl[:, 2],
-                                 xyzl[:, 3]], dtype=dt)
+    dt = np.dtype(
+        [("x", np.float32), ("y", np.float32), ("z", np.float32), ("label", np.float32)]
+    )
+    pc_data = np.rec.fromarrays(
+        [xyzl[:, 0], xyzl[:, 1], xyzl[:, 2], xyzl[:, 3]], dtype=dt
+    )
     pc = PointCloud(md, pc_data)
     return pc
 
@@ -642,7 +673,7 @@ class PointCloud(object):
         self.check_sanity()
 
     def get_metadata(self):
-        """ returns copy of metadata """
+        """returns copy of metadata"""
         metadata = {}
         for k in self.metadata_keys:
             metadata[k] = copy.copy(getattr(self, k))
@@ -651,35 +682,32 @@ class PointCloud(object):
     def check_sanity(self):
         # pdb.set_trace()
         md = self.get_metadata()
-        assert(_metadata_is_consistent(md))
-        assert(len(self.pc_data) == self.points)
-        assert(self.width*self.height == self.points)
-        assert(len(self.fields) == len(self.count))
-        assert(len(self.fields) == len(self.type))
+        assert _metadata_is_consistent(md)
+        assert len(self.pc_data) == self.points
+        assert self.width * self.height == self.points
+        assert len(self.fields) == len(self.count)
+        assert len(self.fields) == len(self.type)
 
     def save(self, fname):
-        self.save_pcd(fname, 'ascii')
+        self.save_pcd(fname, "ascii")
 
     def save_pcd(self, fname, compression=None, **kwargs):
-        if 'data_compression' in kwargs:
-            warnings.warn('data_compression keyword is deprecated for'
-                          ' compression')
-            compression = kwargs['data_compression']
-        with open(fname, 'wb') as f:
+        if "data_compression" in kwargs:
+            warnings.warn("data_compression keyword is deprecated for" " compression")
+            compression = kwargs["data_compression"]
+        with open(fname, "wb") as f:
             point_cloud_to_fileobj(self, f, compression)
 
     def save_pcd_to_fileobj(self, fileobj, compression=None, **kwargs):
-        if 'data_compression' in kwargs:
-            warnings.warn('data_compression keyword is deprecated for'
-                          ' compression')
-            compression = kwargs['data_compression']
+        if "data_compression" in kwargs:
+            warnings.warn("data_compression keyword is deprecated for" " compression")
+            compression = kwargs["data_compression"]
         point_cloud_to_fileobj(self, fileobj, compression)
 
     def save_pcd_to_buffer(self, compression=None, **kwargs):
-        if 'data_compression' in kwargs:
-            warnings.warn('data_compression keyword is deprecated for'
-                          ' compression')
-            compression = kwargs['data_compression']
+        if "data_compression" in kwargs:
+            warnings.warn("data_compression keyword is deprecated for" " compression")
+            compression = kwargs["data_compression"]
         return point_cloud_to_buffer(self, compression)
 
     def save_txt(self, fname):
@@ -698,7 +726,7 @@ class PointCloud(object):
 
     def to_msg(self):
         if not HAS_SENSOR_MSGS:
-            raise NotImplementedError('ROS sensor_msgs not found')
+            raise NotImplementedError("ROS sensor_msgs not found")
         # TODO is there some metadata we want to attach?
         return numpy_pc2.array_to_pointcloud2(self.pc_data)
 
@@ -716,60 +744,62 @@ class PointCloud(object):
 
     @staticmethod
     def from_array(arr):
-        """ create a PointCloud object from an array.
-        """
+        """create a PointCloud object from an array."""
         pc_data = arr.copy()
-        md = {'version': .7,
-              'fields': [],
-              'size': [],
-              'count': [],
-              'width': 0,
-              'height': 1,
-              'viewpoint': [0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0],
-              'points': 0,
-              'type': [],
-              'data': 'binary_compressed'}
-        md['fields'] = pc_data.dtype.names
-        for field in md['fields']:
-            type_, size_ =\
-                numpy_type_to_pcd_type[pc_data.dtype.fields[field][0]]
-            md['type'].append(type_)
-            md['size'].append(size_)
+        md = {
+            "version": 0.7,
+            "fields": [],
+            "size": [],
+            "count": [],
+            "width": 0,
+            "height": 1,
+            "viewpoint": [0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0],
+            "points": 0,
+            "type": [],
+            "data": "binary_compressed",
+        }
+        md["fields"] = pc_data.dtype.names
+        for field in md["fields"]:
+            type_, size_ = numpy_type_to_pcd_type[pc_data.dtype.fields[field][0]]
+            md["type"].append(type_)
+            md["size"].append(size_)
             # TODO handle multicount
-            md['count'].append(1)
-        md['width'] = len(pc_data)
-        md['points'] = len(pc_data)
+            md["count"].append(1)
+        md["width"] = len(pc_data)
+        md["points"] = len(pc_data)
         pc = PointCloud(md, pc_data)
         return pc
 
     @staticmethod
     def from_msg(msg, squeeze=True):
-        """ from pointcloud2 msg
+        """from pointcloud2 msg
         squeeze: fix when clouds get 1 as first dim
         """
         if not HAS_SENSOR_MSGS:
-            raise NotImplementedError('ROS sensor_msgs not found')
-        md = {'version': .7,
-              'fields': [],
-              'size': [],
-              'count': [],
-              'width': 0,
-              'height': 1,
-              'viewpoint': [0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0],
-              'points': 0,
-              'type': [],
-              'data': 'binary_compressed'}
+            raise NotImplementedError("ROS sensor_msgs not found")
+        md = {
+            "version": 0.7,
+            "fields": [],
+            "size": [],
+            "count": [],
+            "width": 0,
+            "height": 1,
+            "viewpoint": [0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0],
+            "points": 0,
+            "type": [],
+            "data": "binary_compressed",
+        }
         for field in msg.fields:
-            md['fields'].append(field.name)
+            md["fields"].append(field.name)
             t, s = pc2_type_to_pcd_type[field.datatype]
-            md['type'].append(t)
-            md['size'].append(s)
+            md["type"].append(t)
+            md["size"].append(s)
             # TODO handle multicount correctly
             if field.count > 1:
-                warnings.warn('fields with count > 1 are not well tested')
-            md['count'].append(field.count)
+                warnings.warn("fields with count > 1 are not well tested")
+            md["count"].append(field.count)
         pc_data = np.squeeze(numpy_pc2.pointcloud2_to_array(msg))
-        md['width'] = len(pc_data)
-        md['points'] = len(pc_data)
+        md["width"] = len(pc_data)
+        md["points"] = len(pc_data)
         pc = PointCloud(md, pc_data)
         return pc

--- a/pypcd/sautil.py
+++ b/pypcd/sautil.py
@@ -1,13 +1,13 @@
-
 import numpy as np
 
-#from sensor_msgs.msg import PointCloud2
-#import pygeom
-#from pypcd import pypcd
-#from pypcd import numpy_pc2
+# from sensor_msgs.msg import PointCloud2
+# import pygeom
+# from pypcd import pypcd
+# from pypcd import numpy_pc2
+
 
 def transform_xyz(T_a_b, xyz):
-    """ Transforms an Nx3 array xyz in frame a to frame b
+    """Transforms an Nx3 array xyz in frame a to frame b
     T_a_b is a 4x4 matrix s.t. xyz_b = T_a_b * xyz_a
     conversely, T_a_b is the pose a in the frame b
     """
@@ -18,58 +18,61 @@ def transform_xyz(T_a_b, xyz):
     xyz_b = np.ascontiguousarray((xyz1_b[:3]).T)
     return xyz_b
 
+
 def transform_cloud_array(T_a_b, pc_data):
-    """ transforms structured array. looks for xyz and xyz_origin """
+    """transforms structured array. looks for xyz and xyz_origin"""
     xyz = get_xyz_array(pc_data, dtype=pc_data.dtype[0])
     xyz_b = transform_xyz(T_a_b, xyz)
-    pc_data['x'] = xyz_b[:,0]
-    pc_data['y'] = xyz_b[:,1]
-    pc_data['z'] = xyz_b[:,2]
-    if 'x_origin' in pc_data:
+    pc_data["x"] = xyz_b[:, 0]
+    pc_data["y"] = xyz_b[:, 1]
+    pc_data["z"] = xyz_b[:, 2]
+    if "x_origin" in pc_data:
         xyz_origin = get_xyz_viewpoint_array(pc_data, dtype=pc_data.dtype[0])
         xyz_origin_b = transform_xyz(T_a_b, xyz_origin)
-        pc_data['x_origin'] = xyz_origin_b[:,0]
-        pc_data['y_origin'] = xyz_origin_b[:,1]
-        pc_data['z_origin'] = xyz_origin_b[:,2]
+        pc_data["x_origin"] = xyz_origin_b[:, 0]
+        pc_data["y_origin"] = xyz_origin_b[:, 1]
+        pc_data["z_origin"] = xyz_origin_b[:, 2]
     return pc_data
 
-def flip_around_x(pc_data):
-    """ flip a structured array around x, in place"""
-    pc_data['y'] = -pc_data['y']
-    pc_data['z'] = -pc_data['z']
 
-    if 'x_origin' in pc_data:
-        pc_data['y_origin'] = -pc_data['y_origin']
-        pc_data['z_origin'] = -pc_data['z_origin']
+def flip_around_x(pc_data):
+    """flip a structured array around x, in place"""
+    pc_data["y"] = -pc_data["y"]
+    pc_data["z"] = -pc_data["z"]
+
+    if "x_origin" in pc_data:
+        pc_data["y_origin"] = -pc_data["y_origin"]
+        pc_data["z_origin"] = -pc_data["z_origin"]
+
 
 def get_xyz_array(pc_data, dtype=np.float32):
-    """ get Nx3 array from structured array """
-    if pc_data.ndim==2 and pc_data.shape[0]==1:
+    """get Nx3 array from structured array"""
+    if pc_data.ndim == 2 and pc_data.shape[0] == 1:
         pc_data = pc_data.squeeze()
-    xyz = np.empty((len(pc_data),3), dtype=dtype)
-    xyz[:,0] = pc_data['x']
-    xyz[:,1] = pc_data['y']
-    xyz[:,2] = pc_data['z']
+    xyz = np.empty((len(pc_data), 3), dtype=dtype)
+    xyz[:, 0] = pc_data["x"]
+    xyz[:, 1] = pc_data["y"]
+    xyz[:, 2] = pc_data["z"]
     return xyz
+
 
 def get_xyz_viewpoint_array(pc_data, dtype=np.float32):
-    """ get Nx3 array from structured array """
-    if pc_data.ndim==2 and pc_data.shape[0]==1:
+    """get Nx3 array from structured array"""
+    if pc_data.ndim == 2 and pc_data.shape[0] == 1:
         pc_data = pc_data.squeeze()
-    xyz = np.empty((len(pc_data),3), dtype=dtype)
-    xyz[:,0] = pc_data['x_origin']
-    xyz[:,1] = pc_data['y_origin']
-    xyz[:,2] = pc_data['z_origin']
+    xyz = np.empty((len(pc_data), 3), dtype=dtype)
+    xyz[:, 0] = pc_data["x_origin"]
+    xyz[:, 1] = pc_data["y_origin"]
+    xyz[:, 2] = pc_data["z_origin"]
     return xyz
 
+
 def get_xyzl_array(pc_data, dtype=np.float32):
-    if pc_data.ndim==2 and pc_data.shape[0]==1:
+    if pc_data.ndim == 2 and pc_data.shape[0] == 1:
         pc_data = pc_data.squeeze()
-    xyzl = np.empty((len(pc_data),4), dtype=dtype)
-    xyzl[:,0] = pc_data['x']
-    xyzl[:,1] = pc_data['y']
-    xyzl[:,2] = pc_data['z']
-    xyzl[:,3] = pc_data['label']
+    xyzl = np.empty((len(pc_data), 4), dtype=dtype)
+    xyzl[:, 0] = pc_data["x"]
+    xyzl[:, 1] = pc_data["y"]
+    xyzl[:, 2] = pc_data["z"]
+    xyzl[:, 3] = pc_data["label"]
     return xyzl
-
-

--- a/pypcd/tests/test_pypcd.py
+++ b/pypcd/tests/test_pypcd.py
@@ -35,93 +35,102 @@ POINTS 19812
 DATA ascii
 """
 
+
 @pytest.fixture
 def pcd_fname():
     import pypcd
-    return os.path.join(pypcd.__path__[0], 'test_data',
-                        'partial_cup_model.pcd')
+
+    return os.path.join(pypcd.__path__[0], "test_data", "partial_cup_model.pcd")
+
 
 @pytest.fixture
 def ascii_pcd_fname():
     import pypcd
-    return os.path.join(pypcd.__path__[0], 'test_data',
-                        'ascii.pcd')
+
+    return os.path.join(pypcd.__path__[0], "test_data", "ascii.pcd")
+
 
 @pytest.fixture
 def bin_pcd_fname():
     import pypcd
-    return os.path.join(pypcd.__path__[0], 'test_data',
-                        'bin.pcd')
+
+    return os.path.join(pypcd.__path__[0], "test_data", "bin.pcd")
+
 
 def cloud_centroid(pc):
     xyz = np.empty((pc.points, 3), dtype=np.float)
-    xyz[:,0] = pc.pc_data['x']
-    xyz[:,1] = pc.pc_data['y']
-    xyz[:,2] = pc.pc_data['z']
+    xyz[:, 0] = pc.pc_data["x"]
+    xyz[:, 1] = pc.pc_data["y"]
+    xyz[:, 2] = pc.pc_data["z"]
     return xyz.mean(0)
+
 
 def test_parse_header():
     from pypcd.pypcd import parse_header
-    lines = header1.split('\n')
+
+    lines = header1.split("\n")
     md = parse_header(lines)
-    assert (md['version'] == '0.7')
-    assert (md['fields'] == ['x', 'y', 'z', 'i'])
-    assert (md['size'] == [4, 4, 4, 4])
-    assert (md['type'] == ['F', 'F', 'F', 'F'])
-    assert (md['count'] == [1, 1, 1, 1])
-    assert (md['width'] == 500028)
-    assert (md['height'] == 1)
-    assert (md['viewpoint'] == [0, 0, 0, 1, 0, 0, 0])
-    assert (md['points'] == 500028)
-    assert (md['data'] == 'binary_compressed')
+    assert md["version"] == "0.7"
+    assert md["fields"] == ["x", "y", "z", "i"]
+    assert md["size"] == [4, 4, 4, 4]
+    assert md["type"] == ["F", "F", "F", "F"]
+    assert md["count"] == [1, 1, 1, 1]
+    assert md["width"] == 500028
+    assert md["height"] == 1
+    assert md["viewpoint"] == [0, 0, 0, 1, 0, 0, 0]
+    assert md["points"] == 500028
+    assert md["data"] == "binary_compressed"
 
 
 def test_from_path(pcd_fname):
     from pypcd import pypcd
+
     pc = pypcd.PointCloud.from_path(pcd_fname)
 
-    fields = 'x y z normal_x normal_y normal_z curvature boundary k vp_x vp_y vp_z principal_curvature_x principal_curvature_y principal_curvature_z pc1 pc2'.split()
+    fields = "x y z normal_x normal_y normal_z curvature boundary k vp_x vp_y vp_z principal_curvature_x principal_curvature_y principal_curvature_z pc1 pc2".split()
     for fld1, fld2 in zip(pc.fields, fields):
-        assert(fld1 == fld2)
-    assert (pc.width == 19812)
-    assert (len(pc.pc_data) == 19812)
+        assert fld1 == fld2
+    assert pc.width == 19812
+    assert len(pc.pc_data) == 19812
 
 
 def test_add_fields(pcd_fname):
     from pypcd import pypcd
+
     pc = pypcd.PointCloud.from_path(pcd_fname)
 
     old_md = pc.get_metadata()
     # new_dt = [(f, pc.pc_data.dtype[f]) for f in pc.pc_data.dtype.fields]
     # new_data = [pc.pc_data[n] for n in pc.pc_data.dtype.names]
-    md = {'fields': ['bla', 'bar'], 'count': [1, 1], 'size': [4, 4],
-          'type': ['F', 'F']}
-    d = np.rec.fromarrays((np.random.random(len(pc.pc_data)),
-                           np.random.random(len(pc.pc_data))))
+    md = {"fields": ["bla", "bar"], "count": [1, 1], "size": [4, 4], "type": ["F", "F"]}
+    d = np.rec.fromarrays(
+        (np.random.random(len(pc.pc_data)), np.random.random(len(pc.pc_data)))
+    )
     newpc = pypcd.add_fields(pc, md, d)
 
     new_md = newpc.get_metadata()
     # print len(old_md['fields']), len(md['fields']), len(new_md['fields'])
     # print old_md['fields'], md['fields'], new_md['fields']
-    assert(len(old_md['fields'])+len(md['fields']) == len(new_md['fields']))
+    assert len(old_md["fields"]) + len(md["fields"]) == len(new_md["fields"])
 
 
 def test_path_roundtrip_ascii(pcd_fname):
     from pypcd import pypcd
+
     pc = pypcd.PointCloud.from_path(pcd_fname)
     md = pc.get_metadata()
 
-    tmp_dirname = tempfile.mkdtemp(suffix='_pypcd', prefix='tmp')
+    tmp_dirname = tempfile.mkdtemp(suffix="_pypcd", prefix="tmp")
 
-    tmp_fname = os.path.join(tmp_dirname, 'out.pcd')
+    tmp_fname = os.path.join(tmp_dirname, "out.pcd")
 
-    pc.save_pcd(tmp_fname, compression='ascii')
+    pc.save_pcd(tmp_fname, compression="ascii")
 
-    assert(os.path.exists(tmp_fname))
+    assert os.path.exists(tmp_fname)
 
     pc2 = pypcd.PointCloud.from_path(tmp_fname)
     md2 = pc2.get_metadata()
-    assert(md == md2)
+    assert md == md2
 
     np.testing.assert_equal(pc.pc_data, pc2.pc_data)
 
@@ -132,22 +141,23 @@ def test_path_roundtrip_ascii(pcd_fname):
 
 def test_path_roundtrip_binary(pcd_fname):
     from pypcd import pypcd
+
     pc = pypcd.PointCloud.from_path(pcd_fname)
     md = pc.get_metadata()
 
-    tmp_dirname = tempfile.mkdtemp(suffix='_pypcd', prefix='tmp')
+    tmp_dirname = tempfile.mkdtemp(suffix="_pypcd", prefix="tmp")
 
-    tmp_fname = os.path.join(tmp_dirname, 'out.pcd')
+    tmp_fname = os.path.join(tmp_dirname, "out.pcd")
 
-    pc.save_pcd(tmp_fname, compression='binary')
+    pc.save_pcd(tmp_fname, compression="binary")
 
-    assert(os.path.exists(tmp_fname))
+    assert os.path.exists(tmp_fname)
 
     pc2 = pypcd.PointCloud.from_path(tmp_fname)
     md2 = pc2.get_metadata()
     for k, v in md2.items():
-        if k == 'data':
-            assert v == 'binary'
+        if k == "data":
+            assert v == "binary"
         else:
             assert v == md[k]
 
@@ -160,22 +170,23 @@ def test_path_roundtrip_binary(pcd_fname):
 
 def test_path_roundtrip_binary_compressed(pcd_fname):
     from pypcd import pypcd
+
     pc = pypcd.PointCloud.from_path(pcd_fname)
     md = pc.get_metadata()
 
-    tmp_dirname = tempfile.mkdtemp(suffix='_pypcd', prefix='tmp')
+    tmp_dirname = tempfile.mkdtemp(suffix="_pypcd", prefix="tmp")
 
-    tmp_fname = os.path.join(tmp_dirname, 'out.pcd')
+    tmp_fname = os.path.join(tmp_dirname, "out.pcd")
 
-    pc.save_pcd(tmp_fname, compression='binary_compressed')
+    pc.save_pcd(tmp_fname, compression="binary_compressed")
 
-    assert(os.path.exists(tmp_fname))
+    assert os.path.exists(tmp_fname)
 
     pc2 = pypcd.PointCloud.from_path(tmp_fname)
     md2 = pc2.get_metadata()
     for k, v in md2.items():
-        if k == 'data':
-            assert v == 'binary_compressed'
+        if k == "data":
+            assert v == "binary_compressed"
         else:
             assert v == md[k]
 
@@ -187,20 +198,21 @@ def test_path_roundtrip_binary_compressed(pcd_fname):
 
 def test_cat_pointclouds(pcd_fname):
     from pypcd import pypcd
+
     pc = pypcd.PointCloud.from_path(pcd_fname)
     pc2 = pc.copy()
-    pc2.pc_data['x'] += 0.1
+    pc2.pc_data["x"] += 0.1
     pc3 = pypcd.cat_point_clouds(pc, pc2)
     for fld, fld3 in zip(pc.fields, pc3.fields):
-        assert(fld == fld3)
-    assert(pc3.width == pc.width+pc2.width)
+        assert fld == fld3
+    assert pc3.width == pc.width + pc2.width
+
 
 def test_ascii_bin1(ascii_pcd_fname, bin_pcd_fname):
     from pypcd import pypcd
+
     apc1 = pypcd.point_cloud_from_path(ascii_pcd_fname)
     bpc1 = pypcd.point_cloud_from_path(bin_pcd_fname)
     am = cloud_centroid(apc1)
     bm = cloud_centroid(bpc1)
-    assert( np.allclose(am, bm) )
-
-
+    assert np.allclose(am, bm)

--- a/pypcd/version.py
+++ b/pypcd/version.py
@@ -66,4 +66,4 @@ VERSION = __version__
 PACKAGES = ['pypcd',
             'pypcd.tests']
 PACKAGE_DATA = {'pypcd': [pjoin('data', '*')]}
-INSTALL_REQUIRES = ["numpy", "python-lzf"]
+INSTALL_REQUIRES = ["numpy", "python-lzf", "pandas"]

--- a/pypcd/version.py
+++ b/pypcd/version.py
@@ -13,15 +13,17 @@ if _version_micro:
 if _version_extra:
     _ver.append(_version_extra)
 
-__version__ = '.'.join(map(str, _ver))
+__version__ = ".".join(map(str, _ver))
 
-CLASSIFIERS = ["Development Status :: 3 - Alpha",
-               "Environment :: Console",
-               "Intended Audience :: Science/Research",
-               "License :: OSI Approved :: MIT License",
-               "Operating System :: OS Independent",
-               "Programming Language :: Python",
-               "Topic :: Scientific/Engineering"]
+CLASSIFIERS = [
+    "Development Status :: 3 - Alpha",
+    "Environment :: Console",
+    "Intended Audience :: Science/Research",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python",
+    "Topic :: Scientific/Engineering",
+]
 
 # Description should be a one-liner:
 description = "Pure Python PCD reader/writer"
@@ -63,7 +65,6 @@ MAJOR = _version_major
 MINOR = _version_minor
 MICRO = _version_micro
 VERSION = __version__
-PACKAGES = ['pypcd',
-            'pypcd.tests']
-PACKAGE_DATA = {'pypcd': [pjoin('data', '*')]}
+PACKAGES = ["pypcd", "pypcd.tests"]
+PACKAGE_DATA = {"pypcd": [pjoin("data", "*")]}
 INSTALL_REQUIRES = ["numpy", "python-lzf", "pandas"]


### PR DESCRIPTION
Since fromstring was deprecated, we can get errors with newer numpy/python/pandas versions saying "use np.frombuffer instead". From what I gathered, it's just equivalent.